### PR TITLE
Transaction service in operator

### DIFF
--- a/backend/src/modules/transactions/service/selectors/where.selector.spec.ts
+++ b/backend/src/modules/transactions/service/selectors/where.selector.spec.ts
@@ -34,6 +34,25 @@ describe('WhereSelector', () => {
     expect(ret).toEqual(transactionsQueryMock);
   });
 
+  it("should call 'in' with the DTO values", async () => {
+    const selectorDTO: SelectorDTO = {
+      Name: 'where',
+      Key: 'Tags',
+      Value: {
+        Relationship: 'lt',
+        Value: ['tag1', 'tag2'],
+      },
+    };
+
+    const selector = new WhereSelector<Transactions>();
+    const ret = selector.ApplySelectorDTO(selectorDTO, transactionsQueryMock);
+    expect(transactionsQueryMock.lt).toBeCalledWith(
+      selectorDTO.Key,
+      selectorDTO.Value.Value,
+    );
+    expect(ret).toEqual(transactionsQueryMock);
+  });
+
   it("should call 'lt' with the DTO values", async () => {
     const selectorDTO: SelectorDTO = {
       Name: 'where',

--- a/backend/src/modules/transactions/service/selectors/where.selector.ts
+++ b/backend/src/modules/transactions/service/selectors/where.selector.ts
@@ -27,6 +27,8 @@ export class WhereSelector<T extends Document> extends Selector<T> {
       query.gt(key, value),
     gte: (query: DocumentQuery<T[], T, {}>, key: string, value: object) =>
       query.gte(key, value),
+    in: (query: DocumentQuery<T[], T, {}>, key: string, value: any[]) =>
+      query.in(key, value),
   };
 
   ApplyValidatedSelectorDTO = (

--- a/frontend/src/Utilities/TransactionQuery/TransactionQuery.spec.ts
+++ b/frontend/src/Utilities/TransactionQuery/TransactionQuery.spec.ts
@@ -96,6 +96,17 @@ describe("TransactionQuery", () => {
     expect(whereDescriptor.Value).toEqual("2017-09-08");
   });
 
+  it("Creates a valid 'in' selector DTO", async () => {
+    const dto = query.in("Tags", ["tag1", "tag2"]).getQueryDTO();
+    expect(Array.isArray(dto.selectors)).toBeTruthy();
+    expect(dto.selectors.length).toEqual(1);
+    expect(dto.selectors[0].Name).toEqual("where");
+    expect(dto.selectors[0].Key).toEqual("Tags");
+    const whereDescriptor = dto.selectors[0].Value as any;
+    expect(whereDescriptor.Relationship).toEqual("in");
+    expect(whereDescriptor.Value).toEqual(["tag1", "tag2"]);
+  });
+
   it("Creates a valid complex query DTO", async () => {
     const dto = query
       .lt("Date", "2017-09-08")

--- a/frontend/src/Utilities/TransactionQuery/TransactionQuery.ts
+++ b/frontend/src/Utilities/TransactionQuery/TransactionQuery.ts
@@ -71,6 +71,11 @@ export class TransactionQuery {
     return this;
   };
 
+  public in = (field: string, value: any): TransactionQuery => {
+    this.selectors.push(this.whereSelector(field, value, "in"));
+    return this;
+  };
+
   public getQueryDTO = (): QueryDTO => {
     const makeQueryDTO = (): QueryDTO => ({
       selectors: this.selectors,


### PR DESCRIPTION
Adds the missing `in` operator to `where` queries in the TransactionService and should close #21 