### PR TITLE
useApi() hook

### DIFF
--- a/frontend/src/Hooks/useApi.ts
+++ b/frontend/src/Hooks/useApi.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { getAccounts, getCategories, getTags } from "../Utilities/Api";
+
+const useApi = <S>(
+  apiMethod: (params?: any) => Promise<S>,
+  initialState: S,
+  params?: any
+) => {
+  const [data, setData] = useState<S>(initialState);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(
+    () => {
+      (async () => {
+        try {
+          const apiData = await apiMethod(params);
+          setData(apiData);
+        } catch (error) {
+          setError(`${(error && error.message) || error || "Error"}`);
+        }
+        setLoading(false);
+      })();
+    },
+    params !== undefined ? [params] : []
+  );
+
+  return {
+    data,
+    loading,
+    error
+  };
+};
+
+export default useApi;
+
+export const useAccounts = () => useApi(getAccounts, []);
+export const useCategories = () => useApi(getCategories, []);
+export const useTags = () => useApi(getTags, []);

--- a/frontend/src/Hooks/useApi.ts
+++ b/frontend/src/Hooks/useApi.ts
@@ -10,8 +10,6 @@ const useApi = <S, A extends any[]>(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  console.log(args);
-
   useEffect(() => {
     (async () => {
       try {

--- a/frontend/src/Hooks/useApi.ts
+++ b/frontend/src/Hooks/useApi.ts
@@ -1,29 +1,28 @@
 import { useEffect, useState } from "react";
 import { getAccounts, getCategories, getTags } from "../Utilities/Api";
 
-const useApi = <S>(
-  apiMethod: (params?: any) => Promise<S>,
+const useApi = <S, A extends any[]>(
+  apiMethod: (...args: A) => Promise<S>,
   initialState: S,
-  params?: any
+  ...args: A
 ) => {
   const [data, setData] = useState<S>(initialState);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(
-    () => {
-      (async () => {
-        try {
-          const apiData = await apiMethod(params);
-          setData(apiData);
-        } catch (error) {
-          setError(`${(error && error.message) || error || "Error"}`);
-        }
-        setLoading(false);
-      })();
-    },
-    params !== undefined ? [params] : []
-  );
+  console.log(args);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const apiData = await apiMethod(...args);
+        setData(apiData);
+      } catch (error) {
+        setError(`${(error && error.message) || error || "Error"}`);
+      }
+      setLoading(false);
+    })();
+  }, args);
 
   return {
     data,

--- a/frontend/src/Utilities/Api.ts
+++ b/frontend/src/Utilities/Api.ts
@@ -1,6 +1,6 @@
 import { IAccount } from "../Models/AccountModel";
 import { IFilters } from "../Models/TransactionFilterModel";
-import { ITransaction } from "../Models/TransactionModel";
+import { ICategory, ITransaction } from "../Models/TransactionModel";
 import { AccountQuery } from "./AccountQuery/AccountQuery";
 import { post } from "./Http";
 import { TransactionQuery } from "./TransactionQuery/TransactionQuery";
@@ -79,7 +79,7 @@ const applyFilters = (
       }
     }
 
-    //TODO: Support for Transfers
+    // TODO: Support for Transfers
   }
 
   return query;
@@ -136,4 +136,14 @@ export const getIncomeByDateRange = async (from: Date, to: Date) => {
     .lt("Date", to)
     .gt("Amount", 0)
     .sum("Account");
+};
+
+export const getCategories = async () => {
+  return ["Beer", "Wine", "Other"].map(
+    (item, index): ICategory => ({ id: index, text: item })
+  );
+};
+
+export const getTags = async () => {
+  return ["foo", "bar", "baz", "bez", "booze", "bamboozle"];
 };

--- a/frontend/src/Views/Accounts/Accounts.tsx
+++ b/frontend/src/Views/Accounts/Accounts.tsx
@@ -1,13 +1,12 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 
 import { Fab, Paper, Theme } from "@material-ui/core";
 import { Add } from "@material-ui/icons";
 import { makeStyles } from "@material-ui/styles";
 import useReactRouter from "use-react-router";
 
-import { IAccount } from "../../Models/AccountModel";
+import { useAccounts } from "../../Hooks/useApi";
 import { AccountsCreateLocation } from "../../routes.constants";
-import { getAccounts } from "../../Utilities/Api";
 import AccountList from "./AccountList";
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -34,17 +33,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 const Accounts = () => {
   const { history } = useReactRouter();
   const classes = useStyles();
-  const [accounts, setAccounts] = useState<IAccount[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setAccounts(await getAccounts());
-      setLoading(false);
-    };
-
-    fetchData();
-  }, []);
+  const { data: accounts, loading } = useAccounts();
 
   const onClick = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
     event.preventDefault();

--- a/frontend/src/Views/Checkout/Checkout.tsx
+++ b/frontend/src/Views/Checkout/Checkout.tsx
@@ -1,12 +1,12 @@
 import { Paper, Theme, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
-import React, { useEffect, useState } from "react";
-import { IAccount } from "../../Models/AccountModel";
+import React, { useState } from "react";
+import { useAccounts, useCategories } from "../../Hooks/useApi";
 import {
   createEmptyTransaction,
   ITransaction
 } from "../../Models/TransactionModel";
-import { getAccounts, postTransaction } from "../../Utilities/Api";
+import { postTransaction } from "../../Utilities/Api";
 import TransactionForm from "./TransactionForm";
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -36,22 +36,13 @@ interface IProps {
   onSubmit?: (transaction: ITransaction) => void;
 }
 
-export interface ICategory {
-  id: number;
-  text: string;
-}
-
 const Checkout = (props: IProps) => {
-  // fetch these from the api aswell
-  const categories = ["Beer", "Wine", "Other"].map(
-    (item, index): ICategory => ({ id: index, text: item })
-  );
+  const { data: categories } = useCategories();
+  const { data: accounts } = useAccounts();
 
-  const [transaction, setTransaction] = React.useState(
-    createEmptyTransaction()
-  );
+  const [transaction, setTransaction] = useState(createEmptyTransaction());
 
-  const [loading, setLoading] = React.useState(false);
+  const [loading, setLoading] = useState(false);
   const classes = useStyles();
 
   const onFieldChange = (field: string, value: any) => {
@@ -74,13 +65,6 @@ const Checkout = (props: IProps) => {
         alert("Success!");
       });
   };
-
-  const [accounts, setAccounts] = useState<IAccount[]>([]);
-  useEffect(() => {
-    (async () => {
-      setAccounts(await getAccounts());
-    })();
-  }, []);
 
   return (
     <React.Fragment>

--- a/frontend/src/Views/Checkout/TransactionForm.tsx
+++ b/frontend/src/Views/Checkout/TransactionForm.tsx
@@ -17,8 +17,7 @@ import {
 import { makeStyles } from "@material-ui/styles";
 import React, { ChangeEvent, SyntheticEvent } from "react";
 import { IAccount } from "../../Models/AccountModel";
-import { ITransaction } from "../../Models/TransactionModel";
-import { ICategory } from "./Checkout";
+import { ICategory, ITransaction } from "../../Models/TransactionModel";
 import TagPicker from "./TagPicker";
 
 const useStyles = makeStyles((theme: Theme) => ({

--- a/frontend/src/Views/Reports/CategoryPie.tsx
+++ b/frontend/src/Views/Reports/CategoryPie.tsx
@@ -1,26 +1,23 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
+import useApi from "../../Hooks/useApi";
 import { IChart } from "../../Models/ChartModel";
 import { getExpenseByCategoryData } from "../../Utilities/Api";
 import PieChart from "./PieChart";
 
-const CategoryPie = () => {
-  const [data, setData] = useState<IChart[]>([]);
-  const [loading, setLoading] = useState(true);
-  useEffect(() => {
-    const fetchData = async () => {
-      const response = await getExpenseByCategoryData();
-      const result = response.map(resp => {
-        return {
-          name: resp.Key,
-          value: 0 - resp.Sum
-        };
-      });
-      setData(result);
-      setLoading(false);
-    };
+const fetchChartData = async () => {
+  const response = await getExpenseByCategoryData();
+  return response.map(
+    (resp): IChart => {
+      return {
+        name: resp.Key,
+        value: 0 - resp.Sum
+      };
+    }
+  );
+};
 
-    fetchData();
-  }, []);
+const CategoryPie = () => {
+  const { data, loading } = useApi(fetchChartData, []);
   return <PieChart data={data} loading={loading} />;
 };
 

--- a/frontend/src/Views/TransactionList/TransactionView.tsx
+++ b/frontend/src/Views/TransactionList/TransactionView.tsx
@@ -1,16 +1,13 @@
 import { Theme } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
-import { IAccount } from "../../Models/AccountModel";
-import { ICategory } from "../../Models/TransactionModel";
-
+import { useAccounts, useCategories, useTags } from "../../Hooks/useApi";
 import {
   emptyFilterObject,
   IFilterItems,
   IFilters
 } from "../../Models/TransactionFilterModel";
-import { getAccounts } from "../../Utilities/Api";
 import CreateTransactionButton from "./CreateTransactionButton";
 import TransactionFilter from "./TransactionFilter";
 import TransactionListContainer from "./TransactionListContainer";
@@ -28,16 +25,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-const hardcodedCategories = ["Beer", "Wine", "Other"].map(
-  (item, index): ICategory => ({ id: index, text: item })
-);
-
 const TransactionView = () => {
   const classes = useStyles();
 
   const [filters, setFilters] = useState<IFilters>(emptyFilterObject);
-  const [categories, setCategories] = useState<ICategory[]>([]);
-  const [accounts, setAccounts] = useState<IAccount[]>([]);
+  const { data: categories } = useCategories();
+  const { data: accounts } = useAccounts();
+  const { data: tags } = useTags();
 
   const filterItems: IFilterItems = {
     accounts: accounts.map(({ id, name }) => ({
@@ -52,18 +46,11 @@ const TransactionView = () => {
       key: item,
       value: item
     })),
-    tags: ["foo", "bar", "baz", "bez", "booze", "bamboozle"].map(item => ({
+    tags: tags.map(item => ({
       key: item,
       value: item
     }))
   };
-
-  useEffect(() => {
-    (async () => {
-      setAccounts(await getAccounts());
-      setCategories(hardcodedCategories);
-    })();
-  }, []);
 
   return (
     <>


### PR DESCRIPTION
- Closes #43 

Instead of doing this:
```typescript
const [accounts, setAccounts] = useState<IAccount[]>([]);
  const [loading, setLoading] = useState(true);

  useEffect(() => {
    const fetchData = async () => {
      setAccounts(await getAccounts());
      setLoading(false);
    };

    fetchData();
  }, []);
```

You can now do this
```typescript
const { data: accounts, loading } = useAccounts();
```

Which under the hood is this
```typescript
const useAccounts = () => useApi(getAccounts, []);
```

In short, it abstracts away the boilerplate associated with getting data from the api