### PR TITLE
Revert "Only install production deps on docker images"

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -9,7 +9,7 @@ COPY .env .env
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 COPY backend/package*.json ./backend/
 
-RUN npm --prefix ./backend install --production
+RUN npm --prefix ./backend install
 
 # Bundle app source
 COPY ./backend ./backend

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 COPY ./frontend/package*.json ./frontend/
 
-RUN npm --prefix frontend install --production
+RUN npm --prefix frontend install
 
 # Bundle app source
 COPY ./frontend ./frontend


### PR DESCRIPTION
This reverts commit 694e181487b7a2504714edf3b20ad688f716daef.
Apparently some transitive `@types` don't get installed and the typescript compilation fails